### PR TITLE
Nested swagger fragments

### DIFF
--- a/example/petstore_domain/README.md
+++ b/example/petstore_domain/README.md
@@ -1,0 +1,15 @@
+# swagger-merger
+
+## petstore_simple
+
+| Directory/File | Description |
+| :---: | :---: |
+| example.sh | Example shell file |
+| definitions/*.json | Link to $ref#* in index.json |
+| definitions/*.yaml | Link to $ref#* in index.yaml |
+| paths/*.json | Link to $ref#* in index.json |
+| paths/*.yaml | Link to $ref#* in index.yaml |
+| petstore_simple.json | Official swagger example |
+| petstore_simple.yaml | Official swagger example |
+| index.json | Main entry swagger example |
+| index.yaml | Main entry swagger example |

--- a/example/petstore_domain/README.md
+++ b/example/petstore_domain/README.md
@@ -5,10 +5,16 @@
 | Directory/File | Description |
 | :---: | :---: |
 | example.sh | Example shell file |
-| definitions/*.json | Link to $ref#* in index.json |
-| definitions/*.yaml | Link to $ref#* in index.yaml |
-| paths/*.json | Link to $ref#* in index.json |
-| paths/*.yaml | Link to $ref#* in index.yaml |
+| definitions/index.json | Definitions entrypoint |
+| definitions/index.yaml | Definitions entrypoint |
+| definitions/error/*.json | Link to $ref in definitions/index.json |
+| definitions/pets/*.json | Link to $ref in definitions/index.json |
+| definitions/error/*.yaml | Link to $ref in definitions/index.yaml |
+| definitions/pets/*.yaml | Link to $ref in definitions/index.yaml |
+| paths/index.json | Paths entrypoint |
+| paths/index.yaml | Paths entrypoint |
+| paths/pets/*.json | Link to $ref#* in paths/index.json |
+| paths/pets/*.yaml | Link to $ref#* in paths/index.yaml |
 | petstore_simple.json | Official swagger example |
 | petstore_simple.yaml | Official swagger example |
 | index.json | Main entry swagger example |

--- a/example/petstore_domain/definitions/error/error.json
+++ b/example/petstore_domain/definitions/error/error.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "required": [
+    "code",
+    "message"
+  ],
+  "properties": {
+    "code": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "message": {
+      "type": "string"
+    }
+  }
+}

--- a/example/petstore_domain/definitions/error/error.yaml
+++ b/example/petstore_domain/definitions/error/error.yaml
@@ -1,0 +1,10 @@
+type: object
+required:
+  - code
+  - message
+properties:
+  code:
+    type: integer
+    format: int32
+  message:
+    type: string

--- a/example/petstore_domain/definitions/index.json
+++ b/example/petstore_domain/definitions/index.json
@@ -1,0 +1,11 @@
+{
+    "errorModel": {
+        "$ref": "./error/error.yaml"
+    },
+    "pet": {
+        "$ref": "./pets/pet.yaml"
+    },
+    "newPet": {
+        "$ref": "./pets/new-pet.yaml"
+    }
+}

--- a/example/petstore_domain/definitions/index.yaml
+++ b/example/petstore_domain/definitions/index.yaml
@@ -1,0 +1,8 @@
+errorModel:
+  $ref: ./error/error.yaml
+
+pet:
+  $ref: ./pets/pet.yaml
+
+newPet:
+  $ref: ./pets/new-pet.yaml

--- a/example/petstore_domain/definitions/pets/new-pet.json
+++ b/example/petstore_domain/definitions/pets/new-pet.json
@@ -1,0 +1,18 @@
+{
+    "type": "object",
+    "required": [
+        "name"
+    ],
+    "properties": {
+        "id": {
+            "type": "integer",
+            "format": "int64"
+        },
+        "name": {
+            "type": "string"
+        },
+        "tag": {
+            "type": "string"
+        }
+    }
+}

--- a/example/petstore_domain/definitions/pets/new-pet.yaml
+++ b/example/petstore_domain/definitions/pets/new-pet.yaml
@@ -1,0 +1,11 @@
+type: object
+required:
+  - name
+properties:
+  id:
+    type: integer
+    format: int64
+  name:
+    type: string
+  tag:
+    type: string

--- a/example/petstore_domain/definitions/pets/pet.json
+++ b/example/petstore_domain/definitions/pets/pet.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "required": [
+    "id",
+    "name"
+  ],
+  "properties": {
+    "id": {
+      "type": "integer",
+      "format": "int64"
+    },
+    "name": {
+      "type": "string"
+    },
+    "tag": {
+      "type": "string"
+    }
+  }
+}

--- a/example/petstore_domain/definitions/pets/pet.yaml
+++ b/example/petstore_domain/definitions/pets/pet.yaml
@@ -1,0 +1,12 @@
+type: object
+required:
+  - id
+  - name
+properties:
+  id:
+    type: integer
+    format: int64
+  name:
+    type: string
+  tag:
+    type: string

--- a/example/petstore_domain/example.sh
+++ b/example/petstore_domain/example.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Merge index.yaml(index.yaml+definitions/*.yaml+paths/*.yaml) into swagger.yaml
+../../bin/swagger-merger.js -i index.yaml
+
+# Merge index.yaml(index.yaml+definitions/*.yaml+paths/*.yaml) into swagger.yaml and compress it.
+#../../bin/swagger-merger.js -i index.yaml -c
+
+# Merge index.json(index.json+definitions/*.json+paths/*.json) into swagger.json
+../../bin/swagger-merger.js -i index.json
+
+# Merge index.json(index.json+definitions/*.json+paths/*.json) into swagger.json and compress it.
+#../../bin/swagger-merger.js -i index.json -c

--- a/example/petstore_domain/index.json
+++ b/example/petstore_domain/index.json
@@ -1,0 +1,35 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Swagger Petstore (Simple)",
+        "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+        "termsOfService": "http://helloreverb.com/terms/",
+        "contact": {
+            "name": "Swagger API team",
+            "email": "foo@example.com",
+            "url": "http://swagger.io"
+        },
+        "license": {
+            "name": "MIT",
+            "url": "http://opensource.org/licenses/MIT"
+        }
+    },
+    "host": "petstore.swagger.io",
+    "basePath": "/api",
+    "schemes": [
+        "http"
+    ],
+    "consumes": [
+        "application/json"
+    ],
+    "produces": [
+        "application/json"
+    ],
+    "paths": {
+        "$ref": "./paths/index.json"
+    },
+    "definitions": {
+        "$ref": "./definitions/index.json"
+    }
+}

--- a/example/petstore_domain/index.yaml
+++ b/example/petstore_domain/index.yaml
@@ -1,0 +1,25 @@
+swagger: '2.0'
+info:
+  version: '1.0.0'
+  title: Swagger Petstore (Domain)
+  description: A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
+  termsOfService: http://helloreverb.com/terms/
+  contact:
+    name: Swagger API team
+    email: foo@example.com
+    url: http://swagger.io
+  license:
+    name: MIT
+    url: http://opensource.org/licenses/MIT
+host: petstore.swagger.io
+basePath: /api
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  $ref: "./paths/index.yaml"
+definitions:
+  $ref: "./definitions/index.yaml"

--- a/example/petstore_domain/index.yml
+++ b/example/petstore_domain/index.yml
@@ -1,0 +1,25 @@
+swagger: '2.0'
+info:
+  version: '1.0.0'
+  title: Swagger Petstore (Simple)
+  description: A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
+  termsOfService: http://helloreverb.com/terms/
+  contact:
+    name: Swagger API team
+    email: foo@example.com
+    url: http://swagger.io
+  license:
+    name: MIT
+    url: http://opensource.org/licenses/MIT
+host: petstore.swagger.io
+basePath: /api
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  $ref: "./paths/index.yaml"
+definitions:
+  $ref: "./definitions/index.yaml"

--- a/example/petstore_domain/paths/index.json
+++ b/example/petstore_domain/paths/index.json
@@ -1,0 +1,8 @@
+{
+    "/pets/{id}": {
+        "$ref": "./pets/pets-id.json"
+    },
+    "/pets": {
+        "$ref": "./pets/pets.json"
+    }
+}

--- a/example/petstore_domain/paths/index.yaml
+++ b/example/petstore_domain/paths/index.yaml
@@ -1,0 +1,5 @@
+/pets/{id}:
+  $ref: ./pets/pets-id.yaml
+
+/pets:
+  $ref: ./pets/pets.yaml

--- a/example/petstore_domain/paths/pets/pets-id.json
+++ b/example/petstore_domain/paths/pets/pets-id.json
@@ -1,0 +1,57 @@
+{
+  "get": {
+    "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+    "operationId": "findPetById",
+    "produces": [
+      "application/json",
+      "application/xml",
+      "text/xml",
+      "text/html"
+    ],
+    "parameters": [{
+      "name": "id",
+      "in": "path",
+      "description": "ID of pet to fetch",
+      "required": true,
+      "type": "integer",
+      "format": "int64"
+    }],
+    "responses": {
+      "200": {
+        "description": "pet response",
+        "schema": {
+          "$ref": "#/definitions/pet"
+        }
+      },
+      "default": {
+        "description": "unexpected error",
+        "schema": {
+          "$ref": "#/definitions/errorModel"
+        }
+      }
+    }
+  },
+  "delete": {
+    "description": "deletes a single pet based on the ID supplied",
+    "operationId": "deletePet",
+    "parameters": [{
+      "name": "id",
+      "in": "path",
+      "description": "ID of pet to delete",
+      "required": true,
+      "type": "integer",
+      "format": "int64"
+    }],
+    "responses": {
+      "204": {
+        "description": "pet deleted"
+      },
+      "default": {
+        "description": "unexpected error",
+        "schema": {
+          "$ref": "#/definitions/errorModel"
+        }
+      }
+    }
+  }
+}

--- a/example/petstore_domain/paths/pets/pets-id.yaml
+++ b/example/petstore_domain/paths/pets/pets-id.yaml
@@ -1,0 +1,41 @@
+get:
+  description: Returns a user based on a single ID, if the user does not have access to the pet
+  operationId: findPetById
+  produces:
+    - application/json
+    - application/xml
+    - text/xml
+    - text/html
+  parameters:
+    - name: id
+      in: path
+      description: ID of pet to fetch
+      required: true
+      type: integer
+      format: int64
+  responses:
+    '200':
+      description: pet response
+      schema:
+        $ref: '#/definitions/pet'
+    default:
+      description: unexpected error
+      schema:
+        $ref: '#/definitions/errorModel'
+delete:
+  description: deletes a single pet based on the ID supplied
+  operationId: deletePet
+  parameters:
+    - name: id
+      in: path
+      description: ID of pet to delete
+      required: true
+      type: integer
+      format: int64
+  responses:
+    '204':
+      description: pet deleted
+    default:
+      description: unexpected error
+      schema:
+        $ref: '#/definitions/errorModel'

--- a/example/petstore_domain/paths/pets/pets.json
+++ b/example/petstore_domain/paths/pets/pets.json
@@ -1,0 +1,79 @@
+{
+  "get": {
+    "description": "Returns all pets from the system that the user has access to",
+    "operationId": "findPets",
+    "produces": [
+      "application/json",
+      "application/xml",
+      "text/xml",
+      "text/html"
+    ],
+    "parameters": [{
+        "name": "tags",
+        "in": "query",
+        "description": "tags to filter by",
+        "required": false,
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "collectionFormat": "csv"
+      },
+      {
+        "name": "limit",
+        "in": "query",
+        "description": "maximum number of results to return",
+        "required": false,
+        "type": "integer",
+        "format": "int32"
+      }
+    ],
+    "responses": {
+      "200": {
+        "description": "pet response",
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pet"
+          }
+        }
+      },
+      "default": {
+        "description": "unexpected error",
+        "schema": {
+          "$ref": "#/definitions/errorModel"
+        }
+      }
+    }
+  },
+  "post": {
+    "description": "Creates a new pet in the store.  Duplicates are allowed",
+    "operationId": "addPet",
+    "produces": [
+      "application/json"
+    ],
+    "parameters": [{
+      "name": "pet",
+      "in": "body",
+      "description": "Pet to add to the store",
+      "required": true,
+      "schema": {
+        "$ref": "#/definitions/newPet"
+      }
+    }],
+    "responses": {
+      "200": {
+        "description": "pet response",
+        "schema": {
+          "$ref": "#/definitions/pet"
+        }
+      },
+      "default": {
+        "description": "unexpected error",
+        "schema": {
+          "$ref": "#/definitions/errorModel"
+        }
+      }
+    }
+  }
+}

--- a/example/petstore_domain/paths/pets/pets.yaml
+++ b/example/petstore_domain/paths/pets/pets.yaml
@@ -1,0 +1,55 @@
+get:
+  description: Returns all pets from the system that the user has access to
+  operationId: findPets
+  produces:
+    - application/json
+    - application/xml
+    - text/xml
+    - text/html
+  parameters:
+    - name: tags
+      in: query
+      description: tags to filter by
+      required: false
+      type: array
+      items:
+        type: string
+      collectionFormat: csv
+    - name: limit
+      in: query
+      description: maximum number of results to return
+      required: false
+      type: integer
+      format: int32
+  responses:
+    '200':
+      description: pet response
+      schema:
+        type: array
+        items:
+          $ref: '#/definitions/pet'
+    default:
+      description: unexpected error
+      schema:
+        $ref: '#/definitions/errorModel'
+post:
+  description: Creates a new pet in the store.  Duplicates are allowed
+  operationId: addPet
+  produces:
+    - application/json
+  parameters:
+    - name: pet
+      in: body
+      description: Pet to add to the store
+      required: true
+      schema:
+        $ref: '#/definitions/newPet'
+  responses:
+    '200':
+      description: pet response
+      schema:
+        $ref: '#/definitions/pet'
+    default:
+      description: unexpected error
+      schema:
+        $ref: '#/definitions/errorModel'

--- a/example/petstore_domain/petstore_simple.json
+++ b/example/petstore_domain/petstore_simple.json
@@ -1,0 +1,229 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Swagger Petstore (Simple)",
+        "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+        "termsOfService": "http://helloreverb.com/terms/",
+        "contact": {
+            "name": "Swagger API team",
+            "email": "foo@example.com",
+            "url": "http://swagger.io"
+        },
+        "license": {
+            "name": "MIT",
+            "url": "http://opensource.org/licenses/MIT"
+        }
+    },
+    "host": "petstore.swagger.io",
+    "basePath": "/api",
+    "schemes": [
+        "http"
+    ],
+    "consumes": [
+        "application/json"
+    ],
+    "produces": [
+        "application/json"
+    ],
+    "paths": {
+        "/pets": {
+            "get": {
+                "description": "Returns all pets from the system that the user has access to",
+                "operationId": "findPets",
+                "produces": [
+                    "application/json",
+                    "application/xml",
+                    "text/xml",
+                    "text/html"
+                ],
+                "parameters": [
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "tags to filter by",
+                        "required": false,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv"
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "maximum number of results to return",
+                        "required": false,
+                        "type": "integer",
+                        "format": "int32"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/pet"
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/errorModel"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a new pet in the store.  Duplicates are allowed",
+                "operationId": "addPet",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "pet",
+                        "in": "body",
+                        "description": "Pet to add to the store",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/newPet"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "schema": {
+                            "$ref": "#/definitions/pet"
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/errorModel"
+                        }
+                    }
+                }
+            }
+        },
+        "/pets/{id}": {
+            "get": {
+                "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+                "operationId": "findPetById",
+                "produces": [
+                    "application/json",
+                    "application/xml",
+                    "text/xml",
+                    "text/html"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID of pet to fetch",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "schema": {
+                            "$ref": "#/definitions/pet"
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/errorModel"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "deletes a single pet based on the ID supplied",
+                "operationId": "deletePet",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID of pet to delete",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "pet deleted"
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/errorModel"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "pet": {
+            "type": "object",
+            "required": [
+                "id",
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "newPet": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "errorModel": {
+            "type": "object",
+            "required": [
+                "code",
+                "message"
+            ],
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/example/petstore_domain/petstore_simple.yaml
+++ b/example/petstore_domain/petstore_simple.yaml
@@ -1,0 +1,157 @@
+swagger: '2.0'
+info:
+  version: '1.0.0'
+  title: Swagger Petstore (Simple)
+  description: A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
+  termsOfService: http://helloreverb.com/terms/
+  contact:
+    name: Swagger API team
+    email: foo@example.com
+    url: http://swagger.io
+  license:
+    name: MIT
+    url: http://opensource.org/licenses/MIT
+host: petstore.swagger.io
+basePath: /api
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /pets:
+    get:
+      description: Returns all pets from the system that the user has access to
+      operationId: findPets
+      produces:
+        - application/json
+        - application/xml
+        - text/xml
+        - text/html
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: csv
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: pet response
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/pet'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/errorModel'
+    post:
+      description: Creates a new pet in the store.  Duplicates are allowed
+      operationId: addPet
+      produces:
+        - application/json
+      parameters:
+        - name: pet
+          in: body
+          description: Pet to add to the store
+          required: true
+          schema:
+            $ref: '#/definitions/newPet'
+      responses:
+        '200':
+          description: pet response
+          schema:
+            $ref: '#/definitions/pet'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/errorModel'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: findPetById
+      produces:
+        - application/json
+        - application/xml
+        - text/xml
+        - text/html
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: pet response
+          schema:
+            $ref: '#/definitions/pet'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/errorModel'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          type: integer
+          format: int64
+      responses:
+        '204':
+          description: pet deleted
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/errorModel'
+definitions:
+  pet:
+    type: object
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  newPet:
+    type: object
+    required:
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  errorModel:
+    type: object
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string

--- a/lib/merge_json.js
+++ b/lib/merge_json.js
@@ -18,14 +18,25 @@ const fmtconv = require('fmtconv')
  */
 function mergeJSON (dir, obj) {
   let doc = JSON.stringify(obj)
+  return JSON.parse(mergeJSONDoc(dir, doc))
+}
 
+/**
+ * Merge JSON swagger doc.
+ *
+ * @param {string} dir
+ * @param {string} doc
+ * @return {string}
+ * @api private
+ */
+function mergeJSONDoc (dir, doc) {
   // merge $ref
   doc = mergeJSONPoundSignRef(dir, doc)
 
   // merge $replace-*
   doc = mergeJSONDollarSignRefPoundSign(dir, doc)
 
-  return JSON.parse(doc)
+  return doc
 }
 
 /**
@@ -40,6 +51,7 @@ function mergeJSONPoundSignRef (dir, doc) {
   return doc.replace(new RegExp(`({[ \n\r]*)("\\$ref")( *):( *)"[^"{}]+"([ \n\r]*})`, 'gm'), s => {
     try {
       let filePath = path.join(dir, JSON.parse(s).$ref)
+      let dirname = path.dirname(filePath)
       try {
         fs.accessSync(filePath, fs.R_OK)
       } catch (e) {
@@ -48,10 +60,10 @@ function mergeJSONPoundSignRef (dir, doc) {
       let fileContext = '' + fs.readFileSync(filePath)
       switch (path.extname(filePath).toLowerCase()) {
         case '.json':
-          return fileContext
+          return mergeJSONDoc(dirname, fileContext)
         case '.yaml':
         case '.yml':
-          return fmtconv.stringYAML2JSON(fileContext)
+          return mergeJSONDoc(dirname, fmtconv.stringYAML2JSON(fileContext))
       }
     } catch (e) {
       throw e
@@ -73,6 +85,7 @@ function mergeJSONDollarSignRefPoundSign (dir, doc) {
     try {
       let filePath = path.join(dir,
         JSON.parse('{' + s + '}')[s.match(new RegExp(`\\$ref#[A-Za-z0-9_#-]+`, 'gm'))])
+      let dirname = path.dirname(filePath)
       try {
         fs.accessSync(filePath, fs.R_OK)
       } catch (e) {
@@ -81,11 +94,11 @@ function mergeJSONDollarSignRefPoundSign (dir, doc) {
       let fileContext = '' + fs.readFileSync(filePath)
       switch (path.extname(filePath).toLowerCase()) {
         case '.json':
-          return fileContext.replace(new RegExp(`(^{)|(}$)`, 'g'), '')
+          return mergeJSONDoc(dirname, fileContext.replace(new RegExp(`(^{)|(}$)`, 'g'), ''))
         case '.yaml':
         case '.yml':
           fileContext = fmtconv.stringYAML2JSON(fileContext)
-          return fileContext.replace(new RegExp(`(^{)|(}$)`, 'g'), '')
+          return mergeJSONDoc(dirname, fileContext.replace(new RegExp(`(^{)|(}$)`, 'g'), ''))
       }
     } catch (e) {
       throw e

--- a/test/merger.test.js
+++ b/test/merger.test.js
@@ -83,3 +83,24 @@ test('merger petstore_simple pass', async (t) => {
     t.pass()
   }).catch(err => t.fail(err))
 })
+
+test('merger petstore_domain pass', async (t) => {
+  await merger({
+    input: './example/petstore_domain/index.yaml'
+  }).then(() => {
+    t.pass()
+  }).catch(err => t.fail(err))
+
+  await merger({
+    input: './example/petstore_domain/index.json',
+    output: './example/petstore_domain/swagger.json'
+  }).then(() => {
+    t.pass()
+  }).catch(err => t.fail(err))
+
+  await merger({
+    input: './example/petstore_domain/index.yml'
+  }).then(() => {
+    t.pass()
+  }).catch(err => t.fail(err))
+})


### PR DESCRIPTION
Hi @WindomZ,

I've forked and changed the swagger-merger to address my needs and think it would be a nice improvement on the tool.

The idea is to let the tool merge $ref tags locateted in another referenced files.
That way its possible to merge the folling structures: 

**swagger.yaml**

``` yaml
swagger: '2.0'
paths:
  ...
definitions:
  $ref: "./definitions/index.yaml"
```

**./definitions/index.yaml**
``` yaml
pet:
  $ref: "./pets/pet.yaml"
```

**./definitions/pets/pet.yaml**
``` yaml
type: object
required:
  - id
  - name
properties:
  id:
    type: integer
    format: int64
  name:
    type: string
  tag:
    type: string
```

Thanks & best regards,
Basask