### PR TITLE
Fix Runtime Error

### DIFF
--- a/bin/swagger-merger.js
+++ b/bin/swagger-merger.js
@@ -28,7 +28,7 @@ program
       output: options.output || '',
       compact: options.compact
     }).catch(e => {
-      console.error(options.parent.debug ? e : e.message)
+      console.error((options.parent && options.parent.debug) ? e : e.message)
     })
   })
 


### PR DESCRIPTION
When running version 1.4.2, I am seeing this error locally and on my build server:

(node:3957) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'debug' of undefined
    at merger.catch.e (/usr/lib/node_modules/swagger-merger/bin/swagger-merger.js:31:36)
    at <anonymous>
    at runMicrotasksCallback (internal/process/next_tick.js:121:5)
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)
    at Function.Module.runMain (module.js:695:11)
    at startup (bootstrap_node.js:191:16)
    at bootstrap_node.js:612:3

This is being caused by the following line of code in swagger-merger.js on line 31:

    console.error(options.parent.debug ? e : e.message)

When running, I am calling swagger-merger using a command line such as:

    swagger-merger -i swagger/swagger.json -o web/apiSpec.json

I tried this in the Webstorm debugger, but I am seeing when I have a source JSON error, the `console.error` statement is being executed but `options.parent` is undefined. I revised this line to also check that `options.parent` exists.