### PR TITLE
 Reference.js escape character support

### DIFF
--- a/lib/reference.js
+++ b/lib/reference.js
@@ -50,6 +50,8 @@ function sliceHashtagJSON (content, hashtag) {
   if (hashtag) {
     let obj = JSON.parse(content)
     hashtag.split('/').every(k => {
+      k = k.replace('~0', '~')
+      k = k.replace('~1', '/')
       obj = Object.getOwnPropertyDescriptor(obj, k).value
       return obj
     })

--- a/lib/reference.js
+++ b/lib/reference.js
@@ -50,8 +50,8 @@ function sliceHashtagJSON (content, hashtag) {
   if (hashtag) {
     let obj = JSON.parse(content)
     hashtag.split('/').every(k => {
-      k = k.replace('~0', '~')
-      k = k.replace('~1', '/')
+      k = k.replace(/~0/g, '~')
+      k = k.replace(/~1/g, '/')
       obj = Object.getOwnPropertyDescriptor(obj, k).value
       return obj
     })


### PR DESCRIPTION
## content

swagger has the following specifications.
https://swagger.io/docs/specification/using-ref/
> / and ~ are special characters in JSON Pointers, and need to be escaped when used literally 

And currently, it can not support the hashtag of the URL.
Therefore, I want to set an escape character and support the hashtag under the path.