### PR TITLE
Add Dockerfile to start Docker image distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:alpine
+
+RUN npm install -g swagger-merger watch
+
+CMD ["swagger-merger"]


### PR DESCRIPTION
@WindomZ 

## Issue

closes https://github.com/WindomZ/swagger-merger/issues/69

## Change

This pull request just adds Dockerfile. For further background, see the issue above.