### PR TITLE
Add warning for if file is not accesible

### DIFF
--- a/lib/merge_json.js
+++ b/lib/merge_json.js
@@ -150,6 +150,7 @@ function mergeJSONByRefHashtag (param, dir, file, doc) {
     try {
       fs.accessSync(filePath, fs.R_OK)
     } catch (e) {
+      console.error(`warn: could not locate ${filePath}! Maybe mistyped file path or missing permission?`)
       return s
     }
     let fileContext = '' + fs.readFileSync(filePath)


### PR DESCRIPTION
Firstly, Thanks for maintain this great library.

I noticed that if file is not accesible by non exists, or missing permission, but swagger-merger supress error and doesn't anything, so I struggled debugging it.
So I added warning if file is not accessible by swagger-merger.

Hope this PR to be merged.

Thanks.