### PR TITLE
the option to print out the version of the program is wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ paths-url:
 ```bash
 $ swagger-merger -h
 
-  Usage: swagger-merger [-h] [-v] [-c] [-o file] <-i file | file>
+  Usage: swagger-merger [-h] [-V] [-c] [-o file] <-i file | file>
 
   Merge multiple swagger files into a swagger file, just support JSON/YAML.
 

--- a/bin/swagger-merger.js
+++ b/bin/swagger-merger.js
@@ -14,7 +14,7 @@ if (require.main === module) {
 
   program
     .version(require('../package.json').version)
-    .usage('[-h] [-v] [-c] [-o file] <-i file | file>')
+    .usage('[-h] [-V] [-c] [-o file] <-i file | file>')
     .description('Merge multiple swagger files into a swagger file, just support JSON/YAML.')
     .option('-i, --input <*.json|yaml|yml file>', 'input a main/entry JSON/YAML swagger file, MANDATORY',
       /^.+\.(json|yaml|yml)$/gi, null)


### PR DESCRIPTION
There is a minor issue with the documentation and the usage string:

The commander module uses -V as a program option instead of a -v to print out the version of the program.