### PR TITLE
[feature] add token to headers if exists

### DIFF
--- a/bin/swagger-merger.js
+++ b/bin/swagger-merger.js
@@ -20,6 +20,7 @@ if (require.main === module) {
       /^.+\.(json|yaml|yml)$/gi, null)
     .option('-o, --output <*.json|yaml|yml file>', 'output a merged JSON/YAML swagger file, default is `swagger.*`',
       /^.+\.(json|yaml|yml)$/gi, null)
+    .option('-t, --token <string>', 'auth token that gets added to header', null, null)
     .option('-c, --compact', 'compact JSON/YAML format string', null, null)
     .option('--debug', 'debug mode, such as print error tracks', null, null)
     .action((options) => {
@@ -31,7 +32,8 @@ if (require.main === module) {
       merger({
         input: options.input || '',
         output: options.output || '',
-        compact: options.compact
+        compact: options.compact,
+        token: program.opts().token || ''
       }).catch(e => {
         if (options.debug) {
           console.error(e)

--- a/lib/merger.js
+++ b/lib/merger.js
@@ -35,7 +35,7 @@ function * merger (param) {
   clean(param.tag)
   merge(param)
 
-  yield downloading(param.tag).then(isCache => {
+  yield downloading(param.tag, param.token).then(isCache => {
     if (isCache) {
       param.input = param.output
       param.dir = path.dirname(param.output)

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -62,14 +62,21 @@ function download (tag, url) {
   return tmpPath
 }
 
-function downloadTasks (tag) {
+function downloadTasks (tag, token) {
   const result = []
   Object.keys(tasks[tag]).forEach((filePath) => {
     const url = tasks[tag][filePath]
     result.push((callback) => {
       const file = fs.createWriteStream(filePath)
       let timeout = null
-      const req = (url.startsWith('https://') ? https : http).get(url, (resp) => {
+      const options = {
+        headers: {}
+      }
+      if (token !== '') {
+        options.headers['Authorization'] = `Bearer ${token}`
+      }
+
+      const req = (url.startsWith('https://') ? https : http).get(url, options, (resp) => {
         if (timeout) {
           clearTimeout(timeout)
         }
@@ -121,14 +128,14 @@ function deleteFolder (dirPath) {
   return false
 }
 
-function downloading (tag) {
+function downloading (tag, token) {
   return new Promise(resolve => {
     if (!tasks[tag]) {
       resolve(fs.existsSync(path.join(tmpDir, tag)))
       return
     }
     async.parallel(
-      downloadTasks(tag),
+      downloadTasks(tag, token),
       function (_, result) {
         result.forEach(r => console.log(r))
         resolve(fs.existsSync(path.join(tmpDir, tag)))


### PR DESCRIPTION
# What

Added in option to pass auth token

# Why

Due to using a private bitbucket repo when trying to download from my swagger file the instance would fail due to needing an access_token passed into the header.